### PR TITLE
Improve setup for conda and uv integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,21 @@ assorted extras.
 ## Installation
 
 ```shell
-# pyvista and ceres-solver are optional
-conda create --name seagull -c conda-forge cgal-cpp pybind11 eigen ceres-solver pyvista
+conda create --name seagull -c conda-forge cgal-cpp pybind11 eigen gmp mpfr 
 conda activate seagull
+```
+
+Pyvista is used as a plotting utility in several bindings, but is completely optional. This can be installed
+into the conda environment via pip:
+
+```shell
+pip install pyvista
+```
+
+Ceres-solver is used in the mesh smoothing module. This module functions without ceres-solver as well, so this dependency is optional. This can be installed with conda:
+
+```shell
+conda install -c conda-forge ceres-solver
 ```
 
 On linux, you'll also need

--- a/setup.py
+++ b/setup.py
@@ -140,6 +140,7 @@ ext_modules = [
         include_dirs=include_dirs,
         library_dirs=library_dirs,
         libraries=cgal_libs + [
+                   'mpfr',
                    'gmp',
                    'boost_thread-mt' if boost_mt else 'boost_thread',
                    'boost_atomic-mt' if boost_mt else 'boost_atomic',

--- a/setup.py
+++ b/setup.py
@@ -139,8 +139,7 @@ ext_modules = [
         ],
         include_dirs=include_dirs,
         library_dirs=library_dirs,
-        libraries=cgal_libs + ['mpfr',
-                   'gmp',
+        libraries=cgal_libs + [
                    'boost_thread-mt' if boost_mt else 'boost_thread',
                    'boost_atomic-mt' if boost_mt else 'boost_atomic',
                    'boost_system',

--- a/setup.py
+++ b/setup.py
@@ -140,6 +140,7 @@ ext_modules = [
         include_dirs=include_dirs,
         library_dirs=library_dirs,
         libraries=cgal_libs + [
+                   'gmp',
                    'boost_thread-mt' if boost_mt else 'boost_thread',
                    'boost_atomic-mt' if boost_mt else 'boost_atomic',
                    'boost_system',

--- a/setup.py
+++ b/setup.py
@@ -73,9 +73,9 @@ if cgal_version >= (5, 0):
 if conda_prefix:
 
     if sys.platform.startswith('win'):
-        prefix = os.path.join(sys.prefix, 'Library\\')
+        prefix = os.path.join(conda_prefix, 'Library\\')
     else:
-        prefix = sys.prefix
+        prefix = conda_prefix
 
     print("Looking for CGAL in: ", prefix)
 


### PR DESCRIPTION
- setup.py now references the conda library path instead of the system path which does not rely on conda's fragile symbolic linking. This fixes the use of the uv caching system
- The README updated to move the optional dependencies into seperate instructions. Particularly useful is removing the suggestion to install pyvista via conda which can cause dll conflicts with pip installs from other packages in the conda environment. 